### PR TITLE
[IMP] l10n_hr: change l10n_hr_vrijeme_izdavanja to Datetime

### DIFF
--- a/l10n_hr_account_base/__manifest__.py
+++ b/l10n_hr_account_base/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": "Croatia accounting localisation",
     "category": "Accounting/Localizations/Croatia",
     "images": [],
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "application": False,
     "author": "Daj Mi 5, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-croatia",

--- a/l10n_hr_account_base/i18n/hr.po
+++ b/l10n_hr_account_base/i18n/hr.po
@@ -233,7 +233,7 @@ msgstr "Hrvatska - Fiskalni podaci"
 #: model:ir.model.fields,help:l10n_hr_account_base.field_account_bank_statement_line__l10n_hr_vrijeme_izdavanja
 #: model:ir.model.fields,help:l10n_hr_account_base.field_account_move__l10n_hr_vrijeme_izdavanja
 #: model:ir.model.fields,help:l10n_hr_account_base.field_account_payment__l10n_hr_vrijeme_izdavanja
-msgid "Croatia Fiskal datetime value as string. shoud respect format: "
+msgid "Croatia Fiskal datetime"
 msgstr "Datum i vrijeme izdavanja"
 
 #. module: l10n_hr_account_base

--- a/l10n_hr_account_base/migrations/17.0.1.0.1/pre-migrate.py
+++ b/l10n_hr_account_base/migrations/17.0.1.0.1/pre-migrate.py
@@ -1,0 +1,12 @@
+def migrate(cr, version):
+    """ Change l10n_hr_vrijeme_izdavanja from char to a Datetime field and convert the value to UTC timezone. """
+
+    cr.execute("""
+        ALTER TABLE account_move
+        ALTER COLUMN l10n_hr_vrijeme_izdavanja
+        TYPE TIMESTAMP WITHOUT TIME ZONE
+        USING TO_TIMESTAMP(l10n_hr_vrijeme_izdavanja, 'DD.MM.YYYY HH24:MI')
+        AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Zagreb';
+    """)
+
+    cr.commit()

--- a/l10n_hr_account_base/models/account_move.py
+++ b/l10n_hr_account_base/models/account_move.py
@@ -25,11 +25,11 @@ class AccountMove(models.Model):
             "Leave blank for current date",
         )
     )
-    l10n_hr_vrijeme_izdavanja = fields.Char(
-        # DB: namjerno kao char da izbjegnem timezone problem!
+    l10n_hr_vrijeme_izdavanja = fields.Datetime(
+        # DB: used to be char, changed to Datetime!
         string="Time Of Invoicing",
         copy=False,
-        help="Croatia Fiskal datetime value as string, should respect format: ",
+        help="Croatia Fiskal datetime",
     )
     l10n_hr_fiskalni_broj = fields.Char(
         string="Fiskal Number",
@@ -209,8 +209,8 @@ class AccountMove(models.Model):
             self.date = fields.Date.context_today(self)
         if not self.l10n_hr_vrijeme_izdavanja:  # depend na l10n_hr_base?
             # DEV NOTE: mozda i ostaviti datetime field? za sad.. char
-            datum = self.company_id.get_l10n_hr_time_formatted()
-            self.l10n_hr_vrijeme_izdavanja = datum["datum_racun"]
+            datum = self.company_id.get_l10n_hr_datetime()
+            self.l10n_hr_vrijeme_izdavanja = datum["server_datetime"]
         # set fiskal number
         if not self.invoice_user_id:
             self.invoice_user_id = self.env.user

--- a/l10n_hr_account_fiskal/models/fiskal_mixin.py
+++ b/l10n_hr_account_fiskal/models/fiskal_mixin.py
@@ -2,6 +2,7 @@ import base64
 import io
 import logging
 from datetime import datetime
+import pytz
 
 import qrcode
 
@@ -35,9 +36,7 @@ class FiscalFiscalMixin(models.AbstractModel):
             # ispis prije poslane fiskalne poruke ili je poslana poruka
             # imala neku gresku pa JIR nije dodjeljen
             url += "zki=" + self.l10n_hr_zki
-        datum = datetime.strptime(
-            self.l10n_hr_vrijeme_izdavanja, "%d.%m.%Y %H:%M"
-        ).strftime("%Y%m%d_%H%M")
+        datum = self.l10n_hr_vrijeme_izdavanja.strftime("%Y%m%d_%H%M")
         url += "&datv=" + datum
         iznos = "&izn=%.2f" % self.amount_total
         url += iznos.replace(".", "")  # bez decimalne tocke u linku!
@@ -298,9 +297,9 @@ class FiscalFiscalMixin(models.AbstractModel):
 
     def _prepare_fisk_racun_dat_vrijeme(self):
         """Convert l10n_hr_vrijeme_izdavanja to fiskalization date format.s"""
-        return datetime.strptime(
-            self.l10n_hr_vrijeme_izdavanja, RACUN_DATETIME_FORMAT
-        ).strftime(FISKAL_DATETIME_FORMAT)
+        formatted_date = self.l10n_hr_vrijeme_izdavanja.replace(tzinfo=pytz.utc).astimezone(
+            pytz.timezone(self.env.context.get("tz") or self.env.user.tz or "UTC")).strftime(FISKAL_DATETIME_FORMAT)
+        return formatted_date
 
     def _get_fisk_racun_type(self, factory, msg_type):
         return factory.type_factory.RacunType
@@ -435,9 +434,11 @@ class FiscalFiscalMixin(models.AbstractModel):
             else:
                 oib = fiskal_data["company_oib"]
 
+            formatted_date = self.l10n_hr_vrijeme_izdavanja.replace(tzinfo=pytz.utc).astimezone(
+                pytz.timezone(self.env.context.get("tz")or self.env.user.tz or "UTC")).strftime(RACUN_DATETIME_FORMAT) or time_start["datum_racun"]
             zki_datalist = [
                 oib,
-                self.l10n_hr_vrijeme_izdavanja or time_start["datum_racun"],
+                formatted_date,
                 fis_racun[0],
                 fis_racun[1],
                 fis_racun[2],

--- a/l10n_hr_account_invoice_tips_fiskal/models/fiskal_mixin.py
+++ b/l10n_hr_account_invoice_tips_fiskal/models/fiskal_mixin.py
@@ -105,9 +105,7 @@ class FiscalFiscalMixin(models.AbstractModel):
 
         # NOTE: check if more than 2 days passed after invoice was fiskalized
         current_time = fields.Datetime.context_timestamp(self, datetime.now()).replace(tzinfo=None)
-        vrijeme_izdavanja = datetime.strptime(
-            self.l10n_hr_vrijeme_izdavanja, RACUN_DATETIME_FORMAT
-        )
+        vrijeme_izdavanja = self.l10n_hr_vrijeme_izdavanja
         if (current_time-vrijeme_izdavanja).days >= 2:
             raise ValidationError(_("It is not possible to fiskalize the tip because more than 2 days "
                 "have passed since the invoice was issued."))

--- a/l10n_hr_base/models/res_company.py
+++ b/l10n_hr_base/models/res_company.py
@@ -86,3 +86,13 @@ class Company(models.Model):
             "time_stamp": tstamp,  # timestamp, za zapis i izračun vremena obrade
             "odoo_datetime": time_now.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
         }
+
+    def get_l10n_hr_datetime(self):
+        ''' Returns user timezone datetime and server datetime (UTC) '''
+        user_tz = self.env.user.tz or self.env.context.get("tz")
+        user_pytz = pytz.timezone(user_tz) if user_tz else pytz.utc
+        tstamp = datetime.now().astimezone(user_pytz)
+        return {
+            "user_datetime": tstamp,
+            "server_datetime": datetime.now(),
+        }


### PR DESCRIPTION
- changed l10n_hr_vrijeme_izdavanja to Datetime from char and supported the change in report/fiskalization

QUERY AFTER DEPLOY (to fix wrong order in daily report)

UPDATE account_move
SET l10n_hr_vrijeme_izdavanja = l10n_hr_vrijeme_izdavanja + INTERVAL '1 second'
WHERE id = 5764;

[info3hr.atlassian.net/browse/RES-318](https://info3hr.atlassian.net/browse/RES-318)