### PR TITLE
[FIX] l10n_hr_account_fiskal: added missing soft post parameter

### DIFF
--- a/l10n_hr_account_fiskal/models/account_move.py
+++ b/l10n_hr_account_fiskal/models/account_move.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         """Extend to verify if required fiscalization data is set on posted invoices"""
-        invoices = super()._post()
+        invoices = super()._post(soft=soft)
         invoices._check_zki_on_confirm()
         return invoices
 


### PR DESCRIPTION
- Added missing parameter for post method on account move
- Resulted in creation of account moves which stay in draft until the payment date
- Now they are posted as soon the payment is created

https://info3hr.atlassian.net/browse/RES-305 