### PR TITLE
[IMP] l10n_hr_account_base: account tax quick search fix

### DIFF
--- a/l10n_hr_account_base/models/__init__.py
+++ b/l10n_hr_account_base/models/__init__.py
@@ -3,3 +3,4 @@ from . import account_journal
 from . import account_move
 from . import fiskal_data
 from . import res_partner
+from . import account_tax

--- a/l10n_hr_account_base/models/account_tax.py
+++ b/l10n_hr_account_base/models/account_tax.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+    _rec_names_search = ['name', 'invoice_label']
+    #NOTE: removed 'description' from _rec_names_search because we have long descriptions of taxes
+    #      that add uneccessary taxes to the search


### PR DESCRIPTION
- removed 'description' from _rec_names_search because we have long descriptions of taxes that add uneccessary taxes to the search

https://info3hr.atlassian.net/browse/RES-364