### PR TITLE
[FIX] l10n_hr_account_base: disable confirmation of account.move without payment method

### DIFF
--- a/l10n_hr_account_base/i18n/hr.po
+++ b/l10n_hr_account_base/i18n/hr.po
@@ -686,6 +686,13 @@ msgid "Payment Devices In This Premisse"
 msgstr "Naplatni uređaji za ovaj prostor"
 
 #. module: l10n_hr_account_base
+#. odoo-python
+#: code:addons/l10n_hr_account_base/models/account_move.py:0
+#, python-format
+msgid "Payment method not selected"
+msgstr "Na računu nije odabran način plaćanja"
+
+#. module: l10n_hr_account_base
 #: model:ir.actions.act_window,name:l10n_hr_account_base.action_fiskal_uredjaj
 #: model:ir.ui.menu,name:l10n_hr_account_base.menu_action_fiskal_uredjaj
 msgid "Payment Registers"

--- a/l10n_hr_account_base/models/account_move.py
+++ b/l10n_hr_account_base/models/account_move.py
@@ -192,6 +192,8 @@ class AccountMove(models.Model):
             res.append(_("No active PoS devices found for this journal"))
         if self.l10n_hr_fiskal_uredjaj_id.state != "active":
             res.append(_("PoS device selected is not active"))
+        if not self.l10n_hr_nacin_placanja:
+            res.append(_("Payment method not selected"))
         return res
 
     def _l10n_hr_post_out_invoice(self):


### PR DESCRIPTION
- raise error if user tries to confirm outgoing move without a payment method selected (as per Croatian Law)

https://info3hr.odoo.com/odoo/timesheets/project.task/12276