### PR TITLE
[FIX] l10n_hr_account_advance_invoice: invoice post fix

### DIFF
--- a/l10n_hr_account_advance_invoice/models/account_move.py
+++ b/l10n_hr_account_advance_invoice/models/account_move.py
@@ -47,96 +47,100 @@ class AccountMove(models.Model):
             line.advance_invoice_id._compute_is_advance_reconciled()
         return res
 
+    def _create_advance_refund_invoice(self):
+        for move in self:
+            if move.advance_invoice or not move.advance_line_ids:
+                return
+            #raise warning if advance amount is larger than invoice amount
+            advance_amount = sum([line.amount for line in move.advance_line_ids])
+            if advance_amount > move.amount_total:
+                raise ValidationError(_("Advance payment amount ({0}) is higher than the invoice amount ({1}). Reduce the amount in the 'Advance' tab on the invoice.").format(advance_amount, move.amount_total))
+            storno_name = move.company_id.storno_advance_account_move_name_prefix
+            counter = 1
+            for line in move.advance_line_ids:
+                name = "{0} {1} {2}".format(move.name, storno_name, counter) if len(move.advance_line_ids) > 1 else "{0} {1}".format(move.name, storno_name)
+                counter += 1
+                new_account_move = {
+                    'partner_id': move.partner_id.id,
+                    'partner_shipping_id': move.partner_shipping_id.id,
+                    'l10n_hr_nacin_placanja': move.l10n_hr_nacin_placanja,
+                    'invoice_date': move.invoice_date,
+                    'date': move.invoice_date,
+                    'invoice_date_due': move.invoice_date_due,
+                    'reference_type': move.reference_type,
+                    'payment_reference': move.payment_reference,
+                    'l10n_hr_date_delivery': move.l10n_hr_date_delivery,
+                    'state': 'draft',
+                    'name': name,
+                    'journal_id': move.journal_id.id,
+                    'currency_id': move.currency_id.id,
+                    'move_type': 'entry',
+                    'auto_post': move.auto_post,
+                    'l10n_hr_fiskalni_broj': name,
+                    'l10n_hr_fiskal_uredjaj_id': move.l10n_hr_fiskal_uredjaj_id.id,
+                    'ref': line.advance_invoice_id.name
+                }
+                res_create_storno_move = move.env['account.move'].create(new_account_move)
+
+                #create account move lines
+                if res_create_storno_move:
+                    advance_journal_lines = line.advance_invoice_id.line_ids
+                    payment_term_line = move.line_ids.filtered(lambda line: line.display_type == "payment_term")
+                    lines_to_create = []
+                    for adv_journal_line in advance_journal_lines:
+                        amount_credit = 0
+                        amount_debit = 0
+                        account_id = adv_journal_line.account_id.id
+                        if adv_journal_line.display_type == "tax" and line.advance_move_storno_line_id.tax_ids == adv_journal_line.tax_line_id:
+                            amount_credit = line.tax_amount * (-1)
+                            amount_debit = 0
+                        elif adv_journal_line.display_type == "product" and line.advance_move_storno_line_id == adv_journal_line:
+                            amount_credit = line.amount_untaxed * (-1)
+                            amount_debit = 0
+                        elif adv_journal_line.display_type == "payment_term":
+                            amount_credit = 0
+                            amount_debit = line.amount * (-1)
+                            account_id = payment_term_line.account_id.id
+                        else:
+                            #continue if not the same product or tax line. seperate storno is create for those cases
+                            continue
+                        lines_to_create.append({
+                            'move_id': res_create_storno_move.id,
+                            'account_id': account_id,
+                            'name': adv_journal_line.name,
+                            'debit': amount_debit,
+                            'credit': amount_credit,
+                            'tax_ids': adv_journal_line.tax_ids,
+                        })
+
+                    res_create_lines = move.env['account.move.line'].create(lines_to_create)
+
+                    #post move manually because it cant be directly set when creating
+                    res_create_storno_move.action_post()
+
+                    #write storno move id to current move
+                    line.storno_move_id = res_create_storno_move.id
+
+                    #when reconciling, dont create exchange difference account move
+                    move = move.with_context(no_exchange_difference=True) #dont create exchange rate difference account move
+
+                    #reconcile
+                    reconciliation_plan = (payment_term_line + res_create_lines.filtered(lambda line: line.account_id == payment_term_line.account_id))
+                    res_reconcile = move.env['account.move.line']._reconcile_plan({reconciliation_plan})
+
+                    #reconcile product line (usually account 2259)
+                    advance_invoice_product_line = line.advance_move_storno_line_id
+                    storno_invoice_product_line = res_create_lines.filtered(lambda line: line.account_id.code == advance_invoice_product_line.account_id.code)
+                    reconciliation_plan_product = (storno_invoice_product_line + advance_invoice_product_line)
+                    res_reconcile_product = move.env['account.move.line']._reconcile_plan({reconciliation_plan_product})
+
+                    #check if advance reconciled
+                    line.advance_invoice_id._compute_is_advance_reconciled()
+
     def action_post(self):
         #override post if current invoice has advance lines
         res = super().action_post()
-        if self.advance_invoice or not self.advance_line_ids:
-            return
-        #raise warning if advance amount is larger than invoice amount
-        advance_amount = sum([line.amount for line in self.advance_line_ids])
-        if advance_amount > self.amount_total:
-            raise ValidationError(_("Advance payment amount ({0}) is higher than the invoice amount ({1}). Reduce the amount in the 'Advance' tab on the invoice.").format(advance_amount, self.amount_total))
-        storno_name = self.company_id.storno_advance_account_move_name_prefix
-        counter = 1
-        for line in self.advance_line_ids:
-            name = "{0} {1} {2}".format(self.name, storno_name, counter) if len(self.advance_line_ids) > 1 else "{0} {1}".format(self.name, storno_name)
-            counter += 1
-            new_account_move = {
-                'partner_id': self.partner_id.id,
-                'partner_shipping_id': self.partner_shipping_id.id,
-                'l10n_hr_nacin_placanja': self.l10n_hr_nacin_placanja,
-                'invoice_date': self.invoice_date,
-                'date': self.invoice_date,
-                'invoice_date_due': self.invoice_date_due,
-                'reference_type': self.reference_type,
-                'payment_reference': self.payment_reference,
-                'l10n_hr_date_delivery': self.l10n_hr_date_delivery,
-                'state': 'draft',
-                'name': name,
-                'journal_id': self.journal_id.id,
-                'currency_id': self.currency_id.id,
-                'move_type': 'entry',
-                'auto_post': self.auto_post,
-                'l10n_hr_fiskalni_broj': name,
-                'l10n_hr_fiskal_uredjaj_id': self.l10n_hr_fiskal_uredjaj_id.id,
-                'ref': line.advance_invoice_id.name
-            }
-            res_create_storno_move = self.env['account.move'].create(new_account_move)
-
-            #create account move lines
-            if res_create_storno_move:
-                advance_journal_lines = line.advance_invoice_id.line_ids
-                payment_term_line = self.line_ids.filtered(lambda line: line.display_type == "payment_term")
-                lines_to_create = []
-                for adv_journal_line in advance_journal_lines:
-                    amount_credit = 0
-                    amount_debit = 0
-                    account_id = adv_journal_line.account_id.id
-                    if adv_journal_line.display_type == "tax" and line.advance_move_storno_line_id.tax_ids == adv_journal_line.tax_line_id:
-                        amount_credit = line.tax_amount * (-1)
-                        amount_debit = 0
-                    elif adv_journal_line.display_type == "product" and line.advance_move_storno_line_id == adv_journal_line:
-                        amount_credit = line.amount_untaxed * (-1)
-                        amount_debit = 0
-                    elif adv_journal_line.display_type == "payment_term":
-                        amount_credit = 0
-                        amount_debit = line.amount * (-1)
-                        account_id = payment_term_line.account_id.id
-                    else:
-                        #continue if not the same product or tax line. seperate storno is create for those cases
-                        continue
-                    lines_to_create.append({
-                        'move_id': res_create_storno_move.id,
-                        'account_id': account_id,
-                        'name': adv_journal_line.name,
-                        'debit': amount_debit,
-                        'credit': amount_credit,
-                        'tax_ids': adv_journal_line.tax_ids,
-                    })
-
-                res_create_lines = self.env['account.move.line'].create(lines_to_create)
-
-                #post move manually because it cant be directly set when creating
-                res_create_storno_move.action_post()
-
-                #write storno move id to current move
-                line.storno_move_id = res_create_storno_move.id
-
-                #when reconciling, dont create exchange difference account move
-                self = self.with_context(no_exchange_difference=True) #dont create exchange rate difference account move
-
-                #reconcile
-                reconciliation_plan = (payment_term_line + res_create_lines.filtered(lambda line: line.account_id == payment_term_line.account_id))
-                res_reconcile = self.env['account.move.line']._reconcile_plan({reconciliation_plan})
-
-                #reconcile product line (usually account 2259)
-                advance_invoice_product_line = line.advance_move_storno_line_id
-                storno_invoice_product_line = res_create_lines.filtered(lambda line: line.account_id.code == advance_invoice_product_line.account_id.code)
-                reconciliation_plan_product = (storno_invoice_product_line + advance_invoice_product_line)
-                res_reconcile_product = self.env['account.move.line']._reconcile_plan({reconciliation_plan_product})
-
-                #check if advance reconciled
-                line.advance_invoice_id._compute_is_advance_reconciled()
+        self._create_advance_refund_invoice()
         return res
 
     def _compute_is_advance_reconciled(self):


### PR DESCRIPTION
Fix the issue when multiple moves are posted at once; we need to check for each move if an advance refund invoice should be created.