### PR TITLE
[IMP] l10n_hr_account_base, l10n_hr_account_fiskal: date sequence check

### DIFF
--- a/l10n_hr_account_base/models/account_move.py
+++ b/l10n_hr_account_base/models/account_move.py
@@ -165,6 +165,13 @@ class AccountMove(models.Model):
             if len(vals) == 1:
                 move.l10n_hr_fiskal_uredjaj_id = vals and vals[0][1]
 
+    def _must_check_constrains_date_sequence(self):
+        """Extend to skip check if l10n_hr_fiskal_uredjaj_id is set."""
+        # NOTE: fiskal number are specific and they don't have date reference in them so we can skip that check
+        if self.l10n_hr_fiskal_uredjaj_id:
+            return False
+        return super()._must_check_constrains_date_sequence()
+
     def _gen_fiskal_number(self):
         self.ensure_one()  # one at a time only!
         prostor = self.l10n_hr_fiskal_uredjaj_id.prostor_id

--- a/l10n_hr_account_fiskal/models/account_move.py
+++ b/l10n_hr_account_fiskal/models/account_move.py
@@ -44,13 +44,6 @@ class AccountMove(models.Model):
                 raise ValidationError(_("""ZKI number is not set on invoice that should be fiscalized.
                     Check if fiscalization is properly configured."""))
 
-    def _must_check_constrains_date_sequence(self):
-        """Extend to skip check if l10n_hr_fiskal_uredjaj_id is set."""
-        # NOTE: fiskal number are specific and they don't have date reference in them so we can skip that check
-        if self.l10n_hr_fiskal_uredjaj_id:
-            return False
-        return super()._must_check_constrains_date_sequence()
-
     def _post(self, soft=True):
         """Extend to verify if required fiscalization data is set on posted invoices"""
         invoices = super()._post(soft=soft)


### PR DESCRIPTION
Extend to skip date sequence check is moved from l10n_hr_account_fiskal to l10n_hr_account_base so that we can use that without fiscalization.