### PR TITLE
[IMP] l10n_hr_account_base, l10n_hr_account_fiskal: fiskal user id

### DIFF
--- a/l10n_hr_account_base/i18n/hr.po
+++ b/l10n_hr_account_base/i18n/hr.po
@@ -27,6 +27,11 @@ msgstr "<strong>Datum isporuke:</strong>"
 
 #. module: l10n_hr_account_base
 #: model_terms:ir.ui.view,arch_db:l10n_hr_account_base.l10n_hr_report_invoice_document
+msgid "<strong>Fiscal User:</strong>"
+msgstr "<strong>Djelatnik:</strong>"
+
+#. module: l10n_hr_account_base
+#: model_terms:ir.ui.view,arch_db:l10n_hr_account_base.l10n_hr_report_invoice_document
 msgid "<strong>Internal number:</strong>"
 msgstr "<strong>Interni broj:</strong>"
 
@@ -362,6 +367,11 @@ msgstr "Naplatni uređaj"
 #: model:ir.model.fields,field_description:l10n_hr_account_base.field_account_payment__l10n_hr_fiskalni_broj
 msgid "Fiskal Number"
 msgstr "Fiskalni broj"
+
+#. module: l10n_hr_account_base
+#: model:ir.model.fields,field_description:l10n_hr_account_base.field_account_move__l10n_hr_fiskal_user_id
+msgid "Fiscal User"
+msgstr "Potvrdio račun"
 
 #. module: l10n_hr_account_base
 #: model:ir.model.fields,field_description:l10n_hr_account_base.field_l10n_hr_fiskal_prostor__message_follower_ids
@@ -901,6 +911,20 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_hr_account_base.field_l10n_hr_fiskal_prostor__journal_ids
 msgid "Used invoicing journals in this business premisse"
 msgstr "Dnevnici izlaznih računa korišteni u ovom prostoru"
+
+#. module: l10n_hr_account_base
+#: model:ir.model.fields,help:l10n_hr_account_base.field_account_move__l10n_hr_fiskal_user_id
+msgid ""
+"User who sent the fiscalisation message to FINA. Can be different from "
+"responsible person on invoice."
+msgstr ""
+"Korisnik koji je poslao poruku fiskalizacije, moguće različit od odgovorne osobe"
+"na računu."
+
+#. module: l10n_hr_account_base
+#: model:ir.model.fields,field_description:l10n_hr_account_base.field_res_company__l10n_hr_vat_on_payment_basis
+msgid "VAT On Payment Basis"
+msgstr "Obračun PDV-a po naplati"
 
 #. module: l10n_hr_account_base
 #: model:ir.model.fields.selection,name:l10n_hr_account_base.selection__l10n_hr_fiskal_uredjaj__state__wait

--- a/l10n_hr_account_base/models/account_move.py
+++ b/l10n_hr_account_base/models/account_move.py
@@ -38,6 +38,16 @@ class AccountMove(models.Model):
         help="Required fiscal number, generated according to "
         "regulations regardless of journal number",
     )
+    l10n_hr_fiskal_user_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Fiscal User",
+        domain=lambda self: self._get_l10n_hr_fiskal_user_id_domain(),
+        default=lambda self: self.env.user.partner_id.id,
+        ondelete='restrict',
+        copy=False,
+        help="User who sent the fiscalisation message to FINA."
+        " Can be different from responsible person on invoice.",
+    )
     # i za ulazne račune se ovdje moze upisati
     l10n_hr_nacin_placanja = fields.Selection(
         selection=[("T", "Bank transfer")],
@@ -164,6 +174,12 @@ class AccountMove(models.Model):
             # NOTE: automatically set l10n_hr_fiskal_uredjaj_id if only one active records exists
             if len(vals) == 1:
                 move.l10n_hr_fiskal_uredjaj_id = vals and vals[0][1]
+
+    def _get_l10n_hr_fiskal_user_id_domain(self):
+        """"Build domain to filter only internal partners."""
+        internal_users = self.env.ref('base.group_user')
+        domain = [('user_ids', 'in', internal_users.users.ids)]
+        return domain
 
     def _must_check_constrains_date_sequence(self):
         """Extend to skip check if l10n_hr_fiskal_uredjaj_id is set."""

--- a/l10n_hr_account_base/models/res_company.py
+++ b/l10n_hr_account_base/models/res_company.py
@@ -36,6 +36,7 @@ class Company(models.Model):
         tracking=True,
         default="r1",  # TODO: multicompany improove!
     )
+    l10n_hr_vat_on_payment_basis = fields.Boolean(string="VAT On Payment Basis")
     l10n_hr_show_required_fisk_fields_on_header = fields.Boolean(
         string="Show Base Fiskalization Fields On Invoice", default=True)
 

--- a/l10n_hr_account_base/report/report_invoice.xml
+++ b/l10n_hr_account_base/report/report_invoice.xml
@@ -62,6 +62,14 @@
                         <strong>Internal number:</strong>
                         <p class="m-0" t-field="o.name" />
                     </div>
+                    <div
+                        class="col-auto col-3 mw-100 mb-2"
+                        t-if="o.l10n_hr_fiskal_user_id"
+                        name="l10n_hr_fiskal_user_id"
+                    >
+                        <strong>Fiscal User:</strong>
+                        <p class="m-0" t-field="o.l10n_hr_fiskal_user_id.display_name" />
+                    </div>
                 </div>
             </t>
         </xpath>

--- a/l10n_hr_account_base/views/account_move_view.xml
+++ b/l10n_hr_account_base/views/account_move_view.xml
@@ -32,6 +32,7 @@
                     <group>
                         <group name="l10n_hr_base_fiskal">
                             <field name="l10n_hr_show_required_fisk_fields_on_header" invisible="1"/>
+                            <field name="l10n_hr_fiskal_user_id" readonly ="state != 'draft'"/>
                             <field name="l10n_hr_date_document" readonly ="state != 'draft'"/>
                             <field name="l10n_hr_vrijeme_izdavanja" readonly="1"/>
                             <field name="l10n_hr_allowed_fiskal_uredjaj_ids" invisible="1"/>

--- a/l10n_hr_account_base/views/res_company_view.xml
+++ b/l10n_hr_account_base/views/res_company_view.xml
@@ -8,6 +8,7 @@
             <group name="l10n_hr_legal" position="after">
                 <group string="Fiscal Data" name="l10n_hr_fiskal">
                     <field name="l10n_hr_tax_model" />
+                    <field name="l10n_hr_vat_on_payment_basis" />
                     <field name="l10n_hr_fiskal_separator" />
                     <field name="l10n_hr_show_required_fisk_fields_on_header" />
                 </group>

--- a/l10n_hr_account_fiskal/i18n/hr.po
+++ b/l10n_hr_account_fiskal/i18n/hr.po
@@ -38,11 +38,6 @@ msgstr ""
 
 #. module: l10n_hr_account_fiskal
 #: model_terms:ir.ui.view,arch_db:l10n_hr_account_fiskal.l10n_hr_fiskal_report_invoice_document
-msgid "<strong>Fiscal User:</strong>"
-msgstr "<strong>Djelatnik:</strong>"
-
-#. module: l10n_hr_account_fiskal
-#: model_terms:ir.ui.view,arch_db:l10n_hr_account_fiskal.l10n_hr_fiskal_report_invoice_document
 msgid "<strong>JIR:</strong>"
 msgstr ""
 
@@ -311,14 +306,6 @@ msgstr "FINA certifikati"
 #: model:ir.model.fields,field_description:l10n_hr_account_fiskal.field_res_company__l10n_hr_fiskal_cert_id
 msgid "Fiscal certificate"
 msgstr "Certifikat za fiskalizaciju"
-
-#. module: l10n_hr_account_fiskal
-#: model:ir.model.fields,field_description:l10n_hr_account_fiskal.field_account_bank_statement_line__l10n_hr_fiskal_user_id
-#: model:ir.model.fields,field_description:l10n_hr_account_fiskal.field_account_move__l10n_hr_fiskal_user_id
-#: model:ir.model.fields,field_description:l10n_hr_account_fiskal.field_account_payment__l10n_hr_fiskal_user_id
-#: model:ir.model.fields,field_description:l10n_hr_account_fiskal.field_l10n_hr_fiskal_mixin__l10n_hr_fiskal_user_id
-msgid "Fiscal User"
-msgstr "Potvrdio račun"
 
 #. module: l10n_hr_account_fiskal
 #. odoo-python
@@ -854,18 +841,6 @@ msgstr "Jedinstvena oznaka poruke"
 #, python-format
 msgid "User OIB is not not entered! It is required for fiscalisation"
 msgstr "OIB korisnika nije unešen! Obavezan podatak za fiskalizaciju računa"
-
-#. module: l10n_hr_account_fiskal
-#: model:ir.model.fields,help:l10n_hr_account_fiskal.field_account_bank_statement_line__l10n_hr_fiskal_user_id
-#: model:ir.model.fields,help:l10n_hr_account_fiskal.field_account_move__l10n_hr_fiskal_user_id
-#: model:ir.model.fields,help:l10n_hr_account_fiskal.field_account_payment__l10n_hr_fiskal_user_id
-#: model:ir.model.fields,help:l10n_hr_account_fiskal.field_l10n_hr_fiskal_mixin__l10n_hr_fiskal_user_id
-msgid ""
-"User who sent the fiscalisation message to FINA. Can be different from "
-"responsible person on invoice."
-msgstr ""
-"Korisnik koji je poslao poruku fiskalizacije, moguće različit od odgovorne osobe"
-"na računu."
 
 #. module: l10n_hr_account_fiskal
 #: model:ir.model.fields,field_description:l10n_hr_account_fiskal.field_account_bank_statement_line__l10n_hr_zki

--- a/l10n_hr_account_fiskal/models/fiskal_mixin.py
+++ b/l10n_hr_account_fiskal/models/fiskal_mixin.py
@@ -74,15 +74,6 @@ class FiscalFiscalMixin(models.AbstractModel):
 
     l10n_hr_zki = fields.Char(string="ZKI", readonly=True, copy=False)
     l10n_hr_jir = fields.Char(string="JIR", readonly=True, copy=False)
-    l10n_hr_fiskal_user_id = fields.Many2one(
-        comodel_name="res.partner",
-        string="Fiscal User",
-        domain=lambda self: self._get_l10n_hr_fiskal_user_id_domain(),
-        ondelete='restrict',
-        copy=False,
-        help="User who sent the fiscalisation message to FINA."
-        " Can be different from responsible person on invoice.",
-    )
     # l10n_hr_vrijeme_xml = fields.Char(  # probably not needed but heck...
     #     string="XML time",
     #     help="Value for fiscalization msg stored as string",
@@ -110,12 +101,6 @@ class FiscalFiscalMixin(models.AbstractModel):
         compute="_compute_l10n_hr_fiskal_qr",
         help="Binary field visible in the interface",
     )
-
-    def _get_l10n_hr_fiskal_user_id_domain(self):
-        """"Build domain to filter only internal partners."""
-        internal_users = self.env.ref('base.group_user')
-        domain = [('user_ids', 'in', internal_users.users.ids)]
-        return domain
 
     def _l10n_hr_post_fiskal_check(self):
         res = []

--- a/l10n_hr_account_fiskal/report/report_invoice.xml
+++ b/l10n_hr_account_fiskal/report/report_invoice.xml
@@ -4,18 +4,6 @@
         id="l10n_hr_fiskal_report_invoice_document"
         inherit_id="l10n_hr_account_base.l10n_hr_report_invoice_document"
     >
-
-        <!-- fiscal user must be shown on croatian invoices -->
-        <xpath expr="//div[@id='l10n_hr_info']/div[@name='interni_broj']" position="after">
-            <div
-                class="col-auto col-3 mw-100 mb-2"
-                t-if="o.l10n_hr_fiskal_user_id"
-                name="l10n_hr_fiskal_user_id"
-            >
-                <strong>Fiscal User:</strong>
-                <p class="m-0" t-field="o.l10n_hr_fiskal_user_id.display_name" />
-            </div>
-        </xpath>
         <!-- hide taxes if company is not in tax system -->
         <xpath expr="//th[@name='th_taxes']" position="attributes">
             <attribute name="t-if">o.company_id.l10n_hr_fiskal_taxative</attribute>

--- a/l10n_hr_account_fiskal/views/account_move_views.xml
+++ b/l10n_hr_account_fiskal/views/account_move_views.xml
@@ -6,10 +6,8 @@
         <field name="inherit_id" ref="l10n_hr_account_base.view_l10n_hr_move_form" />
         <field name="arch" type="xml">
 
-
             <xpath expr="//page[@name='croatia']//field[@name='l10n_hr_nacin_placanja']" position="after">
                 <field name="l10n_hr_paragon_br" readonly ="state != 'draft'" />
-                <field name="l10n_hr_fiskal_user_id" readonly ="state != 'draft'"/>
                 <field name="l10n_hr_late_delivery" readonly="l10n_hr_jir"/>
                 <button string="Fiskaliziraj" type="object" name="button_fiskaliziraj" invisible = "l10n_hr_fiskalni_broj == False or l10n_hr_jir" />
                 <button string="Provjera fiskalizacije" type="object" name="button_provjera_fiskalizacije" invisible = "not l10n_hr_jir" />

--- a/l10n_hr_account_fiskal/views/res_company.xml
+++ b/l10n_hr_account_fiskal/views/res_company.xml
@@ -8,10 +8,14 @@
             ref="l10n_hr_account_base.view_l10n_hr_account_company_form"
         />
         <field name="arch" type="xml">
+            <!-- TODO: move into base module -->
+            <field name="l10n_hr_vat_on_payment_basis" position="before">
+                <field name="l10n_hr_fiskal_taxative" />
+            </field>
+
             <field name="l10n_hr_fiskal_separator" position="after">
                 <field name="l10n_hr_fiskal_cert_id" />
                 <field name="l10n_hr_fiskal_spec" />
-                <field name="l10n_hr_fiskal_taxative" />
                 <field name="l10n_hr_fiskal_on_confirm" />
                 <field name="l10n_hr_fiskal_transaction_type_skip" />
                 <field name="l10n_hr_fiskal_cancel_confirmed_invoice" />


### PR DESCRIPTION
Moved l10n_hr_fiskal_user_id from fiskal into base module because operator is needed on all Croatian invoices.

Added l10n_hr_vat_on_payment_basis field (used in eInvoices)