### PR TITLE
[IMP] l10n_hr_account_base: restrict payment types per fiscal device

### DIFF
--- a/l10n_hr_account_base/models/account_move.py
+++ b/l10n_hr_account_base/models/account_move.py
@@ -74,13 +74,37 @@ class AccountMove(models.Model):
     )
     l10n_hr_show_required_fisk_fields_on_header = fields.Boolean(
         related='company_id.l10n_hr_show_required_fisk_fields_on_header')
-    l10n_hr_is_ref_required = fields.Boolean(compute="_compute_l10n_hr_is_ref_required")
+    l10n_hr_is_ref_required = fields.Boolean(
+        compute="_compute_l10n_hr_is_ref_required"
+    )
+    l10n_hr_allowed_payment_type_ids = fields.Many2many(
+            'l10n_hr.account.payment.type',
+            compute='_compute_l10n_hr_allowed_payment_types'
+        )
 
     _sql_constraints = [(
         'unique_name', "", "Another entry with the same name already exists.",
     ), (
         'unique_name_l10n_hr', "", "Another entry with the same name already exists.",
     )]
+
+    @api.depends('l10n_hr_fiskal_uredjaj_id')
+    def _compute_l10n_hr_allowed_payment_types(self):
+        """ Compute allowed payment types if set on fiskal uredjaj """
+        for move in self:
+            fiskal_uredjaj = move.l10n_hr_fiskal_uredjaj_id
+            if fiskal_uredjaj and fiskal_uredjaj.allowed_payment_type_ids:
+                move.l10n_hr_allowed_payment_type_ids = move.l10n_hr_fiskal_uredjaj_id.allowed_payment_type_ids
+            else:
+                move.l10n_hr_allowed_payment_type_ids = self.env['l10n_hr.account.payment.type'].search([('active', '=', True)])
+
+    @api.onchange('l10n_hr_fiskal_uredjaj_id')
+    def _onchange_l10n_hr_fiskal_uredjaj_id(self):
+        """ Reset payment type only if the device has a restricted list and current is not in it """
+        if self.l10n_hr_fiskal_uredjaj_id and self.l10n_hr_account_payment_type_id:
+            allowed = self.l10n_hr_fiskal_uredjaj_id.allowed_payment_type_ids
+            if allowed and self.l10n_hr_account_payment_type_id not in allowed:
+                self.l10n_hr_account_payment_type_id = False
 
     def _auto_init(self):
         super()._auto_init()

--- a/l10n_hr_account_base/models/account_move.py
+++ b/l10n_hr_account_base/models/account_move.py
@@ -90,21 +90,21 @@ class AccountMove(models.Model):
 
     @api.depends('l10n_hr_fiskal_uredjaj_id')
     def _compute_l10n_hr_allowed_payment_types(self):
-        """ Compute allowed payment types if set on fiskal uredjaj """
-        for move in self:
-            fiskal_uredjaj = move.l10n_hr_fiskal_uredjaj_id
-            if fiskal_uredjaj and fiskal_uredjaj.allowed_payment_type_ids:
-                move.l10n_hr_allowed_payment_type_ids = move.l10n_hr_fiskal_uredjaj_id.allowed_payment_type_ids
-            else:
-                move.l10n_hr_allowed_payment_type_ids = self.env['l10n_hr.account.payment.type'].search([('active', '=', True)])
+        """
+        Compute allowed payment types if set on fiskal uredjaj and
+        reset payment type only if the device has a restricted list and current is not in it
+        """
+        all_payment_types = self.env['l10n_hr.account.payment.type'].search([('active', '=', True)])
 
-    @api.onchange('l10n_hr_fiskal_uredjaj_id')
-    def _onchange_l10n_hr_fiskal_uredjaj_id(self):
-        """ Reset payment type only if the device has a restricted list and current is not in it """
-        if self.l10n_hr_fiskal_uredjaj_id and self.l10n_hr_account_payment_type_id:
-            allowed = self.l10n_hr_fiskal_uredjaj_id.allowed_payment_type_ids
-            if allowed and self.l10n_hr_account_payment_type_id not in allowed:
-                self.l10n_hr_account_payment_type_id = False
+        for move in self:
+            # 1. Update the allowed types
+            fiskal_uredjaj = move.l10n_hr_fiskal_uredjaj_id
+            allowed = fiskal_uredjaj.allowed_payment_type_ids if fiskal_uredjaj and fiskal_uredjaj.allowed_payment_type_ids else all_payment_types
+            move.l10n_hr_allowed_payment_type_ids = allowed
+
+            # 2. Reset the selected payment type if it's no longer valid
+            if move.l10n_hr_account_payment_type_id and move.l10n_hr_account_payment_type_id not in allowed:
+                move.l10n_hr_account_payment_type_id = False
 
     def _auto_init(self):
         super()._auto_init()

--- a/l10n_hr_account_base/models/fiskal_data.py
+++ b/l10n_hr_account_base/models/fiskal_data.py
@@ -224,7 +224,6 @@ class FiskalUredjaj(models.Model):
     allowed_payment_type_ids = fields.Many2many(
         'l10n_hr.account.payment.type',
         string="Allowed Payment Types",
-        domain=[('active', '=', True)]
     )
     state = fields.Selection(
         selection=[

--- a/l10n_hr_account_base/models/fiskal_data.py
+++ b/l10n_hr_account_base/models/fiskal_data.py
@@ -221,7 +221,11 @@ class FiskalUredjaj(models.Model):
         domain=[("code", "=", "l10n_hr.fiscal")],
         help="Shoud be defined with no prefix or suffix, used only for this PoS",
     )
-
+    allowed_payment_type_ids = fields.Many2many(
+        'l10n_hr.account.payment.type',
+        string="Allowed Payment Types",
+        domain=[('active', '=', True)]
+    )
     state = fields.Selection(
         selection=[
             ("draft", "Draft"),

--- a/l10n_hr_account_base/views/account_move_view.xml
+++ b/l10n_hr_account_base/views/account_move_view.xml
@@ -40,7 +40,14 @@
                             <field name="l10n_hr_fiskal_uredjaj_id" widget="selection" invisible ="not l10n_hr_fiskal_uredjaj_visible or l10n_hr_show_required_fisk_fields_on_header " domain="[('id', 'in', l10n_hr_allowed_fiskal_uredjaj_ids)]" readonly="state != 'draft'"/>
                             <!-- until fiscalisation module for cash payments has only one selectable ooption -->
                             <!-- <field name="l10n_hr_nacin_placanja" invisible="move_type not in ['out_invoice','out_refund'] or l10n_hr_show_required_fisk_fields_on_header" readonly="state != 'draft'"/> -->
-                            <field name="l10n_hr_account_payment_type_id" invisible="move_type not in ['out_invoice','out_refund'] or l10n_hr_show_required_fisk_fields_on_header" readonly="state != 'draft'" options="{'no_open': True}"/>
+                            <field name="l10n_hr_allowed_payment_type_ids" invisible="1"/>
+                            <field
+                                name="l10n_hr_account_payment_type_id"
+                                invisible="move_type not in ['out_invoice','out_refund'] or l10n_hr_show_required_fisk_fields_on_header"
+                                readonly="state != 'draft'"
+                                options="{'no_open': True}"
+                                domain="[('id', 'in', l10n_hr_allowed_payment_type_ids)]"
+                            />
                         </group>
                     </group>
                 </page>
@@ -49,7 +56,13 @@
             <field name="invoice_vendor_bill_id" position="after">
                 <field name="l10n_hr_fiskal_uredjaj_id" widget="selection" invisible="not l10n_hr_fiskal_uredjaj_visible or not l10n_hr_show_required_fisk_fields_on_header" domain="[('id', 'in', l10n_hr_allowed_fiskal_uredjaj_ids)]" readonly="state != 'draft'"/>
                 <!-- <field name="l10n_hr_nacin_placanja" invisible="move_type not in ['out_invoice','out_refund'] or not l10n_hr_show_required_fisk_fields_on_header" readonly="state != 'draft'"/> -->
-                <field name="l10n_hr_account_payment_type_id" invisible="move_type not in ['out_invoice','out_refund'] or not l10n_hr_show_required_fisk_fields_on_header" readonly="state != 'draft'" options="{'no_open': True}"/>
+                <field
+                    name="l10n_hr_account_payment_type_id"
+                    invisible="move_type not in ['out_invoice','out_refund'] or not l10n_hr_show_required_fisk_fields_on_header"
+                    readonly="state != 'draft'"
+                    options="{'no_open': True}"
+                    domain="[('id', 'in', l10n_hr_allowed_payment_type_ids)]"
+                />
             </field>
 
             <field name="ref" position="before">

--- a/l10n_hr_account_base/views/fiskal_data_views.xml
+++ b/l10n_hr_account_base/views/fiskal_data_views.xml
@@ -150,6 +150,7 @@
                     <field name="sljed_racuna" readonly="1" invisible="1" />
                     <field name="oznaka_uredjaj" readonly= "lock==True" />
                     <field name="sequence_id" readonly= "lock==True" invisible ="sljed_racuna == 'P'" />
+                    <field name="allowed_payment_type_ids" widget="many2many_tags"/>
                     <field name="journal_ids" widget="many2many_tags" readonly= "lock==True" />
                 </group>
                 </sheet>


### PR DESCRIPTION
- Add allowed_payment_type_ids to l10n.hr.fiskal.uredjaj.
- Implement dynamic domain on invoices to filter payment types based on the selected device.
- Default behavior: if no allowed types are specified on the device, all active payment types remain available.